### PR TITLE
Make unnest work with old and new tidyr versions

### DIFF
--- a/R/extractors.R
+++ b/R/extractors.R
@@ -91,5 +91,12 @@ get_list_col <- function(df, list_col = NULL, key = "npi") {
     sep_val <- NULL
   }
 
-  tidyr::unnest(df, !!rlang::sym(list_col), names_sep = sep_val)
+  # Make unnest work with older and newer versions of tidyr
+  if (tidyr_new_interface()) {
+    # Code for tidyr v1.0.0
+    tidyr::unnest(df, !!rlang::sym(list_col), .sep = sep_val)
+  } else {
+    # Code for v0.8.3
+    tidyr::unnest(df, !!rlang::sym(list_col), names_sep = sep_val)
+  }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -180,3 +180,11 @@ make_full_address <-
         stringr::str_trim(df[[postal_code]], "both")
       )
   }
+
+#' Check for new tidyr interface
+#'
+#' @return Boolean indicating whether a newer version of tidyr is installed
+#' @noRd
+tidyr_new_interface <- function() {
+  utils::packageVersion("tidyr") > "0.8.99"
+}


### PR DESCRIPTION
Make code that uses unnest() work with old and new interfaces used by different versions of tidyr.

See https://tidyr.tidyverse.org/articles/in-packages.html#tidyr-v0-8-3---v1-0-0