### PR TITLE
Update epoch field conversion to date

### DIFF
--- a/R/extractors.R
+++ b/R/extractors.R
@@ -30,8 +30,16 @@ tidy_results <- function(content) {
 
 #' @noRd
 clean_results <- function(results) {
+  convert_epoch_date <- function(col){
+    ifelse(
+      nchar(as.character(col)) == 13,
+      as.numeric(col)/1000,
+      as.numeric(col)
+    )
+  }
+
   epoch_to_date <- purrr::as_mapper(
-    ~ as.POSIXct(as.numeric(.x)/1000, origin = "1970-01-01", tz = "UTC")
+    ~ as.POSIXct(convert_epoch_date(.x), origin = "1970-01-01", tz = "UTC")
   )
 
   results %>%

--- a/R/extractors.R
+++ b/R/extractors.R
@@ -31,7 +31,7 @@ tidy_results <- function(content) {
 #' @noRd
 clean_results <- function(results) {
   epoch_to_date <- purrr::as_mapper(
-    ~ as.POSIXct(.x, origin = "1970-01-01", tz = "UTC")
+    ~ as.POSIXct(as.numeric(.x)/1000, origin = "1970-01-01", tz = "UTC")
   )
 
   results %>%


### PR DESCRIPTION
Fixes #74 by adjusting clean_results() to handle 13 digit epoch character values. 

Useful links the explain approach: 
- [example API query](https://npiregistry.cms.hhs.gov/api/?number=&enumeration_type=&taxonomy_description=&first_name=&use_first_name_alias=&last_name=&organization_name=&address_purpose=&city=New%20York%20City&state=&postal_code=&country_code=&limit=&skip=&pretty=&version=2.1)
- [epochconvertor tool for quick checking](https://www.epochconverter.com/)
- [solution for converting 13 digit epochs to dttm](https://stackoverflow.com/questions/54768565/conversion-of-epoch-time-string-to-human-readable-date-in-r-script)