### PR TITLE
Align docs and behavior: address purpose, empty results, validation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,4 +56,4 @@ VignetteBuilder:
 Encoding: UTF-8
 Language: en-US
 LazyData: true
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,11 @@ Authors@R: c(
     person(c("Emily", "C."), "Zabor", , "zabore2@ccf.org", role = "rev", 
            comment = c(ORCID = "0000-0002-1402-4498"))
   )
+Author: Frank Farach [aut, cre, cph],
+    Sam Parmar [ctb],
+    Matthias Grenié [rev],
+    Emily C. Zabor [rev]
+Maintainer: Frank Farach <frank.farach@gmail.com>
 Description: Access the United States National Provider Identifier
     Registry API <https://npiregistry.cms.hhs.gov/api/>. Obtain and transform
     administrative data linked to a specific individual or organizational

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # npi (development version)
 
+## MINOR IMPROVEMENTS
+
+  * `npi_search()` now normalizes `address_purpose` values to API constants and accepts case-insensitive input.
+  * `npi_is_valid()` now supports vector inputs and returns logical vectors.
+  * `npi_search()` returns a typed empty `npi_results` object when no records are found.
+
+## DOCUMENTATION FIXES
+
+  * Clarified `npi_summarize()` taxonomy fallback behavior when no primary taxonomy is marked.
+
 # npi 0.2.0
 
 ## MINOR IMPROVEMENTS

--- a/R/extractors.R
+++ b/R/extractors.R
@@ -12,7 +12,7 @@ tidy_results <- function(content) {
   content <- unlist(content, recursive = FALSE)
 
   tibble::tibble(
-    npi = pluck_vector_from_content(content, "number"),
+    npi = as.integer(pluck_vector_from_content(content, "number")),
     enumeration_type = pluck_vector_from_content(content, "enumeration_type"),
     basic = list_to_tibble(content, "basic", 1),
     other_names = list_to_tibble(content, "other_names", 2),

--- a/R/npi_results_s3.R
+++ b/R/npi_results_s3.R
@@ -102,7 +102,9 @@ validate_npi_results <- function(x, ...) {
 #'     \item{\code{primary_practice_address}}{Full address of the provider's
 #'       primary practice location}
 #'     \item{\code{phone}}{Provider's telephone number}
-#'     \item{\code{primary_taxonomy}}{Primary taxonomy description}
+#'     \item{\code{primary_taxonomy}}{Primary taxonomy description. If no
+#'       taxonomy is marked as primary for a record, the first listed taxonomy
+#'       is used.}
 #'   }
 #' @examples
 #' data(npis)
@@ -159,7 +161,9 @@ npi_summarize.npi_results <- function(object, ...) {
 #'     \item{\code{primary_practice_address}}{Full address of the provider's
 #'       primary practice location}
 #'     \item{\code{phone}}{Provider's telephone number}
-#'     \item{\code{primary_taxonomy}}{Primary taxonomy description}
+#'     \item{\code{primary_taxonomy}}{Primary taxonomy description. If no
+#'       taxonomy is marked as primary for a record, the first listed taxonomy
+#'       is used.}
 #'   }
 #' @family summary functions
 #' @examples

--- a/R/npi_results_s3.R
+++ b/R/npi_results_s3.R
@@ -15,6 +15,28 @@ new_npi_results <- function(x, ...) {
   )
 }
 
+#' Construct an empty \code{npi_results} object
+#'
+#' @return A 0-row tibble with \code{npi_results} class
+#' @keywords internal
+new_empty_npi_results <- function() {
+  new_npi_results(
+    tibble::tibble(
+      npi = integer(),
+      enumeration_type = character(),
+      basic = vector("list", 0),
+      other_names = vector("list", 0),
+      identifiers = vector("list", 0),
+      taxonomies = vector("list", 0),
+      addresses = vector("list", 0),
+      practice_locations = vector("list", 0),
+      endpoints = vector("list", 0),
+      created_date = as.POSIXct(numeric(), origin = "1970-01-01", tz = "UTC"),
+      last_updated_date = as.POSIXct(numeric(), origin = "1970-01-01", tz = "UTC")
+    )
+  )
+}
+
 
 
 #' Validate input as S3 \code{npi_results} object

--- a/R/npi_results_s3.R
+++ b/R/npi_results_s3.R
@@ -18,7 +18,7 @@ new_npi_results <- function(x, ...) {
 #' Construct an empty \code{npi_results} object
 #'
 #' @return A 0-row tibble with \code{npi_results} class
-#' @keywords internal
+#' @noRd
 new_empty_npi_results <- function() {
   new_npi_results(
     tibble::tibble(

--- a/R/npi_search.R
+++ b/R/npi_search.R
@@ -214,7 +214,7 @@ npi_process_results <- function(params) {
   results <- npi_control_requests(params, user_n)
 
   if (rlang::is_empty(results)) {
-    return(tibble::tibble())
+    return(new_empty_npi_results())
   }
 
   results %>%

--- a/R/npi_search.R
+++ b/R/npi_search.R
@@ -140,14 +140,7 @@ npi_search <- function(number = NULL,
     use_first_name_alias <- ifelse(isTRUE(use_first_name_alias), "True", "False")
   }
 
-  if (!is.null(address_purpose)) {
-    vals <- c("location", "mailing", "primary", "SECONDARY")
-    if (!address_purpose %in% vals) {
-      msg <- paste("`address_purpose` must be one of:",
-                   stringr::str_c(vals, collapse = ", "))
-      rlang::abort(msg)
-    }
-  }
+  address_purpose <- normalize_address_purpose(address_purpose)
 
   if (limit < 1L || limit > 1200) {
     rlang::abort("`limit` must be a number between 1 and 1200.")
@@ -182,6 +175,30 @@ npi_search <- function(number = NULL,
       limit = limit
     )
   )
+}
+
+
+
+#' Normalize address_purpose input
+#' @param address_purpose Optional address purpose value
+#' @return Normalized address purpose or NULL
+#' @noRd
+normalize_address_purpose <- function(address_purpose) {
+  if (is.null(address_purpose)) {
+    return(NULL)
+  }
+
+  vals <- c("LOCATION", "MAILING", "PRIMARY", "SECONDARY")
+  address_purpose_norm <- toupper(address_purpose)
+
+  if (!address_purpose_norm %in% vals) {
+    msg <- paste("`address_purpose` must be one of:",
+      stringr::str_c(vals, collapse = ", ")
+    )
+    rlang::abort(msg)
+  }
+
+  address_purpose_norm
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -62,21 +62,21 @@ abort_bad_argument <- function(arg, must, not = NULL,
 #' npi_is_valid(1234567898) # FALSE
 #' @export
 npi_is_valid <- function(x) {
-  if (stringr::str_length(x) != 10 ||
-    stringr::str_detect(x, "\\d{10}",
-      negate = TRUE
-    )) {
+  x <- as.character(x)
+
+  invalid <- stringr::str_length(x) != 10 |
+    stringr::str_detect(x, "^\\d{10}$", negate = TRUE)
+
+  if (any(invalid)) {
     rlang::abort("`x` must be a 10-digit number.")
   }
-
-  x <- as.character(x)
 
   # Prefix the NPI with code for US health applications per US governement
   # requirements
   x <- paste0("80840", x)
 
   # Validate number using the Luhn algorithm
-  checkLuhn::checkLuhn(x)
+  unname(vapply(x, checkLuhn::checkLuhn, logical(1L)))
 }
 
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -103,7 +103,7 @@ If you're comfortable [working with list columns](https://r4ds.had.co.nz/many-mo
 
 ### Summarizing results
 
-Run `npi_summarize()` on your results to see a more human-readable overview of your search results. Specifically, the function returns the NPI number, provider's name, enumeration type (individual or organizational provider), primary address, phone number, and primary taxonomy (area of practice):
+Run `npi_summarize()` on your results to see a more human-readable overview of your search results. Specifically, the function returns the NPI number, provider's name, enumeration type (individual or organizational provider), primary address, phone number, and primary taxonomy (area of practice). If no taxonomy is marked as primary for a record, the first taxonomy listed for that NPI is returned:
 
 ```{r summarize-nyc}
 npi_summarize(nyc)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
 # npi <img src="man/figures/logo.png" align="right" height="139" />
@@ -46,24 +45,24 @@ There are three ways to install the `npi` package:
 
 1.  Install from CRAN:
 
-``` r
-install.packages("npi")
-library(npi)
-```
+<!-- -->
 
-2.  Install from [R-universe](https://ropensci.org/r-universe/):
+    install.packages("npi")
+    library(npi)
 
-``` r
-install.packages("npi", repos = "https://ropensci.r-universe.dev")
-library(npi)
-```
+1.  Install from [R-universe](https://ropensci.org/r-universe/):
 
-3.  Install from GitHub using the `devtools` package:
+<!-- -->
 
-``` r
-devtools::install_github("ropensci/npi")
-library(npi)
-```
+    install.packages("npi", repos = "https://ropensci.r-universe.dev")
+    library(npi)
+
+1.  Install from GitHub using the `devtools` package:
+
+<!-- -->
+
+    devtools::install_github("ropensci/npi")
+    library(npi)
 
 ## Usage
 
@@ -86,30 +85,25 @@ parameters](https://npiregistry.cms.hhs.gov/registry/help-api). Let’s
 say we wanted to find up to 10 providers with primary locations in New
 York City:
 
-``` r
-nyc <- npi_search(city = "New York City")
-```
+    nyc <- npi_search(city = "New York City")
 
-``` r
-# Your results may differ since the data in the NPPES database changes over time
-nyc
-#> # A tibble: 10 × 11
-#>       npi enume…¹ basic    other_…² identi…³ taxono…⁴ addres…⁵ practi…⁶ endpoi…⁷
-#>  *  <int> <chr>   <list>   <list>   <list>   <list>   <list>   <list>   <list>  
-#>  1 1.19e9 Indivi… <tibble> <tibble> <tibble> <tibble> <tibble> <tibble> <tibble>
-#>  2 1.31e9 Indivi… <tibble> <tibble> <tibble> <tibble> <tibble> <tibble> <tibble>
-#>  3 1.64e9 Indivi… <tibble> <tibble> <tibble> <tibble> <tibble> <tibble> <tibble>
-#>  4 1.35e9 Indivi… <tibble> <tibble> <tibble> <tibble> <tibble> <tibble> <tibble>
-#>  5 1.56e9 Indivi… <tibble> <tibble> <tibble> <tibble> <tibble> <tibble> <tibble>
-#>  6 1.79e9 Indivi… <tibble> <tibble> <tibble> <tibble> <tibble> <tibble> <tibble>
-#>  7 1.56e9 Indivi… <tibble> <tibble> <tibble> <tibble> <tibble> <tibble> <tibble>
-#>  8 1.96e9 Organi… <tibble> <tibble> <tibble> <tibble> <tibble> <tibble> <tibble>
-#>  9 1.43e9 Indivi… <tibble> <tibble> <tibble> <tibble> <tibble> <tibble> <tibble>
-#> 10 1.33e9 Indivi… <tibble> <tibble> <tibble> <tibble> <tibble> <tibble> <tibble>
-#> # … with 2 more variables: created_date <dttm>, last_updated_date <dttm>, and
-#> #   abbreviated variable names ¹​enumeration_type, ²​other_names, ³​identifiers,
-#> #   ⁴​taxonomies, ⁵​addresses, ⁶​practice_locations, ⁷​endpoints
-```
+    # Your results may differ since the data in the NPPES database changes over time
+    nyc
+    #> # A tibble: 10 × 11
+    #>       npi enumeration_type basic    other_names identifiers taxonomies addresses
+    #>  *  <int> <chr>            <list>   <list>      <list>      <list>     <list>   
+    #>  1 1.19e9 Individual       <tibble> <tibble>    <tibble>    <tibble>   <tibble> 
+    #>  2 1.31e9 Individual       <tibble> <tibble>    <tibble>    <tibble>   <tibble> 
+    #>  3 1.64e9 Individual       <tibble> <tibble>    <tibble>    <tibble>   <tibble> 
+    #>  4 1.35e9 Individual       <tibble> <tibble>    <tibble>    <tibble>   <tibble> 
+    #>  5 1.56e9 Individual       <tibble> <tibble>    <tibble>    <tibble>   <tibble> 
+    #>  6 1.79e9 Individual       <tibble> <tibble>    <tibble>    <tibble>   <tibble> 
+    #>  7 1.56e9 Individual       <tibble> <tibble>    <tibble>    <tibble>   <tibble> 
+    #>  8 1.96e9 Organization     <tibble> <tibble>    <tibble>    <tibble>   <tibble> 
+    #>  9 1.43e9 Individual       <tibble> <tibble>    <tibble>    <tibble>   <tibble> 
+    #> 10 1.33e9 Individual       <tibble> <tibble>    <tibble>    <tibble>   <tibble> 
+    #> # ℹ 4 more variables: practice_locations <list>, endpoints <list>,
+    #> #   created_date <dttm>, last_updated_date <dttm>
 
 The full search results have four regular vector columns, `npi`,
 `enumeration_type`, `created_date`, and `last_updated_date` and seven
@@ -144,26 +138,24 @@ Run `npi_summarize()` on your results to see a more human-readable
 overview of your search results. Specifically, the function returns the
 NPI number, provider’s name, enumeration type (individual or
 organizational provider), primary address, phone number, and primary
-taxonomy (area of practice):
+taxonomy (area of practice). If no taxonomy is marked as primary for a
+record, the first taxonomy listed for that NPI is returned:
 
-``` r
-npi_summarize(nyc)
-#> # A tibble: 10 × 6
-#>           npi name                                 enume…¹ prima…² phone prima…³
-#>         <int> <chr>                                <chr>   <chr>   <chr> <chr>  
-#>  1 1194276360 ALYSSA COWNAN                        Indivi… 5 E 98… 212-… Physic…
-#>  2 1306849641 MARK MOHRMANN                        Indivi… 16 PAR… 212-… Orthop…
-#>  3 1639173065 SAKSHI DUA                           Indivi… 10 E 1… 212-… Nurse …
-#>  4 1346604592 SARAH LOWRY                          Indivi… 1335 D… 614-… Occupa…
-#>  5 1558362566 AMY TIERSTEN                         Indivi… 1176 5… 212-… Psychi…
-#>  6 1790786416 NOAH GOLDMAN                         Indivi… 140 BE… 973-… Intern…
-#>  7 1558713628 ROBYN NOHLING                        Indivi… 9 HOPE… 781-… Nurse …
-#>  8 1962983775 LENOX HILL MEDICAL ANESTHESIOLOGY, … Organi… 100 E … 212-… Intern…
-#>  9 1427454529 YONGHONG TAN                         Indivi… 34 MAP… 203-… Obstet…
-#> 10 1326403213 RAJEE KRAUSE                         Indivi… 12401 … 347-… Nurse …
-#> # … with abbreviated variable names ¹​enumeration_type,
-#> #   ²​primary_practice_address, ³​primary_taxonomy
-```
+    npi_summarize(nyc)
+    #> # A tibble: 10 × 6
+    #>         npi name  enumeration_type primary_practice_add…¹ phone primary_taxonomy
+    #>       <int> <chr> <chr>            <chr>                  <chr> <chr>           
+    #>  1   1.19e9 ALYS… Individual       5 E 98TH ST FL SREET4… 212-… Physician Assis…
+    #>  2   1.31e9 MARK… Individual       16 PARK PL, NEW YORK,… 212-… Orthopaedic Sur…
+    #>  3   1.64e9 SAKS… Individual       10 E 102ND ST, NEW YO… 212-… Nurse Practitio…
+    #>  4   1.35e9 SARA… Individual       1335 DUBLIN RD STE 20… 614-… Occupational Th…
+    #>  5   1.56e9 AMY … Individual       1176 5TH AVE, NEW YOR… 212-… Psychiatry & Ne…
+    #>  6   1.79e9 NOAH… Individual       140 BERGEN STREET LEV… 973-… Internal Medici…
+    #>  7   1.56e9 ROBY… Individual       9 HOPE AVE STE 500, W… 781-… Nurse Practitio…
+    #>  8   1.96e9 LENO… Organization     100 E 77TH ST, NEW YO… 212-… Internal Medici…
+    #>  9   1.43e9 YONG… Individual       34 MAPLE ST, NORWALK,… 203-… Obstetrics & Gy…
+    #> 10   1.33e9 RAJE… Individual       12401 E 17TH AVE, AUR… 347-… Nurse Anestheti…
+    #> # ℹ abbreviated name: ¹​primary_practice_address
 
 ### Flattening results
 
@@ -188,29 +180,27 @@ a flatter (i.e., unnested and merged) structure that’s easier to use.
 results from `npi_search()`. One extreme is to flatten everything at
 once:
 
-``` r
-npi_flatten(nyc)
-#> # A tibble: 48 × 42
-#>           npi basic_fi…¹ basic…² basic…³ basic…⁴ basic…⁵ basic…⁶ basic…⁷ basic…⁸
-#>         <int> <chr>      <chr>   <chr>   <chr>   <chr>   <chr>   <chr>   <chr>  
-#>  1 1194276360 ALYSSA     COWNAN  PA      NO      F       2016-1… 2018-0… A      
-#>  2 1194276360 ALYSSA     COWNAN  PA      NO      F       2016-1… 2018-0… A      
-#>  3 1306849641 MARK       MOHRMA… MD      NO      M       2005-0… 2019-0… A      
-#>  4 1306849641 MARK       MOHRMA… MD      NO      M       2005-0… 2019-0… A      
-#>  5 1306849641 MARK       MOHRMA… MD      NO      M       2005-0… 2019-0… A      
-#>  6 1306849641 MARK       MOHRMA… MD      NO      M       2005-0… 2019-0… A      
-#>  7 1326403213 RAJEE      KRAUSE  AGPCNP… NO      F       2015-1… 2019-0… A      
-#>  8 1326403213 RAJEE      KRAUSE  AGPCNP… NO      F       2015-1… 2019-0… A      
-#>  9 1326403213 RAJEE      KRAUSE  AGPCNP… NO      F       2015-1… 2019-0… A      
-#> 10 1326403213 RAJEE      KRAUSE  AGPCNP… NO      F       2015-1… 2019-0… A      
-#> # … with 38 more rows, 33 more variables: basic_name <chr>,
-#> #   basic_name_prefix <chr>, basic_middle_name <chr>,
-#> #   basic_organization_name <chr>, basic_organizational_subpart <chr>,
-#> #   basic_authorized_official_credential <chr>,
-#> #   basic_authorized_official_first_name <chr>,
-#> #   basic_authorized_official_last_name <chr>,
-#> #   basic_authorized_official_middle_name <chr>, …
-```
+    npi_flatten(nyc)
+    #> # A tibble: 48 × 42
+    #>           npi basic_first_name basic_last_name basic_credential
+    #>         <int> <chr>            <chr>           <chr>           
+    #>  1 1194276360 ALYSSA           COWNAN          PA              
+    #>  2 1194276360 ALYSSA           COWNAN          PA              
+    #>  3 1306849641 MARK             MOHRMANN        MD              
+    #>  4 1306849641 MARK             MOHRMANN        MD              
+    #>  5 1306849641 MARK             MOHRMANN        MD              
+    #>  6 1306849641 MARK             MOHRMANN        MD              
+    #>  7 1326403213 RAJEE            KRAUSE          AGPCNP-C        
+    #>  8 1326403213 RAJEE            KRAUSE          AGPCNP-C        
+    #>  9 1326403213 RAJEE            KRAUSE          AGPCNP-C        
+    #> 10 1326403213 RAJEE            KRAUSE          AGPCNP-C        
+    #> # ℹ 38 more rows
+    #> # ℹ 38 more variables: basic_sole_proprietor <chr>, basic_gender <chr>,
+    #> #   basic_enumeration_date <chr>, basic_last_updated <chr>, basic_status <chr>,
+    #> #   basic_name <chr>, basic_name_prefix <chr>, basic_middle_name <chr>,
+    #> #   basic_organization_name <chr>, basic_organizational_subpart <chr>,
+    #> #   basic_authorized_official_credential <chr>,
+    #> #   basic_authorized_official_first_name <chr>, …
 
 However, due to the number of fields and the large number of potential
 combinations of values, this approach is best suited to small datasets.
@@ -220,41 +210,39 @@ list columns you want and merging after the fact. For example, to
 flatten basic provider and provider taxonomy information, supply the
 corresponding list columns as a vector of names to the `cols` argument:
 
-``` r
-# Flatten basic provider info and provider taxonomy, preserving the relationship
-# of each to NPI number and discarding other list columns.
-npi_flatten(nyc, cols = c("basic", "taxonomies"))
-#> # A tibble: 20 × 26
-#>           npi basic_fi…¹ basic…² basic…³ basic…⁴ basic…⁵ basic…⁶ basic…⁷ basic…⁸
-#>         <int> <chr>      <chr>   <chr>   <chr>   <chr>   <chr>   <chr>   <chr>  
-#>  1 1194276360 ALYSSA     COWNAN  PA      NO      F       2016-1… 2018-0… A      
-#>  2 1306849641 MARK       MOHRMA… MD      NO      M       2005-0… 2019-0… A      
-#>  3 1306849641 MARK       MOHRMA… MD      NO      M       2005-0… 2019-0… A      
-#>  4 1326403213 RAJEE      KRAUSE  AGPCNP… NO      F       2015-1… 2019-0… A      
-#>  5 1326403213 RAJEE      KRAUSE  AGPCNP… NO      F       2015-1… 2019-0… A      
-#>  6 1326403213 RAJEE      KRAUSE  AGPCNP… NO      F       2015-1… 2019-0… A      
-#>  7 1346604592 SARAH      LOWRY   OTR/L   YES     F       2016-0… 2018-0… A      
-#>  8 1346604592 SARAH      LOWRY   OTR/L   YES     F       2016-0… 2018-0… A      
-#>  9 1427454529 YONGHONG   TAN     <NA>    NO      F       2014-1… 2018-1… A      
-#> 10 1558362566 AMY        TIERST… M.D.    YES     F       2005-0… 2019-0… A      
-#> 11 1558713628 ROBYN      NOHLING FNP-BC… YES     F       2016-0… 2018-0… A      
-#> 12 1558713628 ROBYN      NOHLING FNP-BC… YES     F       2016-0… 2018-0… A      
-#> 13 1558713628 ROBYN      NOHLING FNP-BC… YES     F       2016-0… 2018-0… A      
-#> 14 1558713628 ROBYN      NOHLING FNP-BC… YES     F       2016-0… 2018-0… A      
-#> 15 1558713628 ROBYN      NOHLING FNP-BC… YES     F       2016-0… 2018-0… A      
-#> 16 1558713628 ROBYN      NOHLING FNP-BC… YES     F       2016-0… 2018-0… A      
-#> 17 1639173065 SAKSHI     DUA     M.D.    YES     F       2005-0… 2019-0… A      
-#> 18 1639173065 SAKSHI     DUA     M.D.    YES     F       2005-0… 2019-0… A      
-#> 19 1790786416 NOAH       GOLDMAN M.D.    NO      M       2005-0… 2018-0… A      
-#> 20 1962983775 <NA>       <NA>    <NA>    <NA>    <NA>    2018-0… 2018-0… A      
-#> # … with 17 more variables: basic_name <chr>, basic_name_prefix <chr>,
-#> #   basic_middle_name <chr>, basic_organization_name <chr>,
-#> #   basic_organizational_subpart <chr>,
-#> #   basic_authorized_official_credential <chr>,
-#> #   basic_authorized_official_first_name <chr>,
-#> #   basic_authorized_official_last_name <chr>,
-#> #   basic_authorized_official_middle_name <chr>, …
-```
+    # Flatten basic provider info and provider taxonomy, preserving the relationship
+    # of each to NPI number and discarding other list columns.
+    npi_flatten(nyc, cols = c("basic", "taxonomies"))
+    #> # A tibble: 20 × 26
+    #>           npi basic_first_name basic_last_name basic_credential    
+    #>         <int> <chr>            <chr>           <chr>               
+    #>  1 1194276360 ALYSSA           COWNAN          PA                  
+    #>  2 1306849641 MARK             MOHRMANN        MD                  
+    #>  3 1306849641 MARK             MOHRMANN        MD                  
+    #>  4 1326403213 RAJEE            KRAUSE          AGPCNP-C            
+    #>  5 1326403213 RAJEE            KRAUSE          AGPCNP-C            
+    #>  6 1326403213 RAJEE            KRAUSE          AGPCNP-C            
+    #>  7 1346604592 SARAH            LOWRY           OTR/L               
+    #>  8 1346604592 SARAH            LOWRY           OTR/L               
+    #>  9 1427454529 YONGHONG         TAN             <NA>                
+    #> 10 1558362566 AMY              TIERSTEN        M.D.                
+    #> 11 1558713628 ROBYN            NOHLING         FNP-BC, RD, LDN, MSN
+    #> 12 1558713628 ROBYN            NOHLING         FNP-BC, RD, LDN, MSN
+    #> 13 1558713628 ROBYN            NOHLING         FNP-BC, RD, LDN, MSN
+    #> 14 1558713628 ROBYN            NOHLING         FNP-BC, RD, LDN, MSN
+    #> 15 1558713628 ROBYN            NOHLING         FNP-BC, RD, LDN, MSN
+    #> 16 1558713628 ROBYN            NOHLING         FNP-BC, RD, LDN, MSN
+    #> 17 1639173065 SAKSHI           DUA             M.D.                
+    #> 18 1639173065 SAKSHI           DUA             M.D.                
+    #> 19 1790786416 NOAH             GOLDMAN         M.D.                
+    #> 20 1962983775 <NA>             <NA>            <NA>                
+    #> # ℹ 22 more variables: basic_sole_proprietor <chr>, basic_gender <chr>,
+    #> #   basic_enumeration_date <chr>, basic_last_updated <chr>, basic_status <chr>,
+    #> #   basic_name <chr>, basic_name_prefix <chr>, basic_middle_name <chr>,
+    #> #   basic_organization_name <chr>, basic_organizational_subpart <chr>,
+    #> #   basic_authorized_official_credential <chr>,
+    #> #   basic_authorized_official_first_name <chr>,
+    #> #   basic_authorized_official_last_name <chr>, …
 
 ### Validating NPIs
 
@@ -264,13 +252,11 @@ digit](https://en.wikipedia.org/wiki/Check_digit) for error-checking
 purposes. Use `npi_is_valid()` to check whether an NPI number you’ve
 encountered is validly constructed:
 
-``` r
-# Validate NPIs
-npi_is_valid(1234567893)
-#> [1] TRUE
-npi_is_valid(1234567898)
-#> [1] FALSE
-```
+    # Validate NPIs
+    npi_is_valid(1234567893)
+    #> [1] TRUE
+    npi_is_valid(1234567898)
+    #> [1] FALSE
 
 Note that this function doesn’t check whether the NPI numbers are
 activated or deactivated (see
@@ -286,15 +272,13 @@ the software interacting with an API to tell it who or what is making
 the request. This helps the API’s maintainers understand what systems
 are using the API. By default, when `npi` makes a request to the NPPES
 API, the request header references the name of the package and the URL
-for the repository (e.g., ‘npi/0.2.0
+for the repository (e.g., ‘npi/0.2.0.9000
 (<https://github.com/ropensci/npi>)’). If you want to set a custom user
 agent, update the value of the `npi_user_agent` option. For example, for
-version 1.0.0 of an app called “my_app”, you could run the following
+version 1.0.0 of an app called “my\_app”, you could run the following
 code:
 
-``` r
-options(npi_user_agent = "my_app/1.0.0")
-```
+    options(npi_user_agent = "my_app/1.0.0")
 
 ## Package Website
 

--- a/man/npi_summarize.Rd
+++ b/man/npi_summarize.Rd
@@ -22,7 +22,9 @@ Tibble containing the following columns:
     \item{\code{primary_practice_address}}{Full address of the provider's
       primary practice location}
     \item{\code{phone}}{Provider's telephone number}
-    \item{\code{primary_taxonomy}}{Primary taxonomy description}
+    \item{\code{primary_taxonomy}}{Primary taxonomy description. If no
+      taxonomy is marked as primary for a record, the first listed taxonomy
+      is used.}
   }
 }
 \description{

--- a/man/npi_summarize.npi_results.Rd
+++ b/man/npi_summarize.npi_results.Rd
@@ -22,7 +22,9 @@ Tibble containing the following columns:
     \item{\code{primary_practice_address}}{Full address of the provider's
       primary practice location}
     \item{\code{phone}}{Provider's telephone number}
-    \item{\code{primary_taxonomy}}{Primary taxonomy description}
+    \item{\code{primary_taxonomy}}{Primary taxonomy description. If no
+      taxonomy is marked as primary for a record, the first listed taxonomy
+      is used.}
   }
 }
 \description{

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -152,6 +152,12 @@ test_that("npi_search() throws an error when argument values are invalid", {
   expect_error(npi_search(city = arg), class = err)
 })
 
+test_that("npi_search() normalizes address_purpose values", {
+  mockery::stub(npi_search, "npi_process_results", function(params) params)
+  res <- npi_search(address_purpose = "secondary")
+  expect_equal(res$address_purpose, "SECONDARY")
+})
+
 
 with_mock_api({
   test_that("We can catch request logic errors in the API response", {

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -247,7 +247,8 @@ test_that("The initial message accurately reports the requested number of record
 with_mock_api({
   test_that("npi_process_results returns an empty tibble when npi_search returns zero records", {
     res <- npi_search(city = "ZZZZZZZ")
-    expect_identical(res, tibble::tibble())
+    expect_s3_class(res, "npi_results")
+    expect_identical(res, new_empty_npi_results())
   })
 })
 

--- a/tests/testthat/test-validators.R
+++ b/tests/testthat/test-validators.R
@@ -11,6 +11,14 @@ test_that("npi_is_valid() uses the Luhn algorithm", {
   expect_false(npi_is_valid(1234567898))
 })
 
+test_that("npi_is_valid() works with vector inputs", {
+  expect_equal(
+    npi_is_valid(c(1234567893, 1234567898)),
+    c(TRUE, FALSE)
+  )
+  expect_error(npi_is_valid(c(1234567893, "bad")))
+})
+
 test_that("hyphenate_full_zip() works correctly", {
   bad_zips_chr <- c(
     "902100201", "90210", "9021", "90210-", "90210-0",


### PR DESCRIPTION
  Summary

  - Normalize `address_purpose` inputs to the API’s uppercase values and add test coverage.
  - Return a typed `npi_results` object for zero‑record searches.
  - Vectorize `npi_is_valid()` to accept multiple NPIs.
  - Clarify taxonomy fallback behavior in `npi_summarize` docs and `README`.
  - Add Author/Maintainer fields to satisfy R CMD check.

  Changes

  - `npi_search()` accepts case‑insensitive address_purpose and normalizes to `LOCATION/MAILING/PRIMARY/SECONDARY`.
  - `npi_search()` returns a structured empty npi_results instead of bare tibble().
  - `npi_is_valid()` now accepts vectors and returns a logical vector.
  - Docs updated to note taxonomy fallback when no primary is marked.
  - NPI extraction coerced to integer to keep binding stable.

  Testing

  - R CMD build .
  - R CMD check npi_0.2.0.9000.tar.gz

  Notes

  - No behavior changes beyond the described alignments; existing pipelines should remain compatible.